### PR TITLE
docs(PR template): Fix typos in instructions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ _Put an `x` in the boxes that apply_
 
 Checklist
 -------------------------------------------
-_Put an `` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._
+_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._
 
 - [ ] My changeset covers only what is described above (no extraneous changes)
 - [ ] Lint and unit tests pass locally with my changes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,4 +24,4 @@ _Put an `x` in the boxes that apply. You can also fill these out after creating 
 
 Further comments
 -------------------------------------------
-If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...x
+If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...


### PR DESCRIPTION
Proposed changes
-------------------------------------------
The "x" to put in the boxes that apply under the Checklist heading somehow fell to the bottom of the template, under the Further comments section. You can see the current state below:

Types of changes
-------------------------------------------
What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

Checklist
-------------------------------------------
_Put an `` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [x] My changeset covers only what is described above (no extraneous changes)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged downstream

Further comments
-------------------------------------------
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...x
